### PR TITLE
Update the sentence-transformers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ protobuf==3.20
 python-Levenshtein==0.12.2
 scikit-learn==1.0.2
 scipy==1.7.3
-sentence-transformers==2.2.0
+sentence-transformers==2.2.2
 tqdm==4.62.3
 transformers==4.21.2


### PR DESCRIPTION
This fixes `ModuleNotFoundError: No module named 'huggingface_hub.snapshot_download'` on a fresh install.